### PR TITLE
Adds SPEEX codec support to RTPEndpoint. Fitted for 6.5.0

### DIFF
--- a/src/gst-plugins/commons/constants.h
+++ b/src/gst-plugins/commons/constants.h
@@ -76,6 +76,7 @@ G_BEGIN_DECLS
 /* RTP enconding names */
 #define OPUS_ENCONDING_NAME "OPUS"
 #define VP8_ENCONDING_NAME "VP8"
+#define SPEEX_ENCONDING_NAME "speex"
 
 G_END_DECLS
 #endif /* __KMS_CONSTANTS_H__ */

--- a/src/gst-plugins/commons/kmsenctreebin.c
+++ b/src/gst-plugins/commons/kmsenctreebin.c
@@ -46,6 +46,7 @@ typedef enum
   X264,
   OPENH264,
   OPUS,
+  SPEEX,
   UNSUPPORTED
 } EncoderType;
 
@@ -77,6 +78,8 @@ kms_enc_tree_bin_get_name_from_type (EncoderType enc_type)
       return "openh264";
     case OPUS:
       return "opus";
+    case SPEEX:
+      return "speex";
     case UNSUPPORTED:
     default:
       return NULL;
@@ -183,6 +186,11 @@ configure_encoder (GstElement * encoder, EncoderType type, gint target_bitrate,
           "perfect-timestamp", TRUE, NULL);
       break;
     }
+    case SPEEX:
+    {
+      g_object_set (G_OBJECT (encoder), "complexity", 4, NULL);
+      break;
+    }
     default:
       GST_DEBUG ("Codec %" GST_PTR_FORMAT
           " not configured because it is not supported", encoder);
@@ -207,6 +215,8 @@ kms_enc_tree_bin_set_encoder_type (KmsEncTreeBin * self)
     self->priv->enc_type = OPENH264;
   } else if (g_str_has_prefix (name, "opusenc")) {
     self->priv->enc_type = OPUS;
+  } else if (g_str_has_prefix (name, "speexenc")) {
+    self->priv->enc_type = SPEEX;
   } else {
     self->priv->enc_type = UNSUPPORTED;
   }

--- a/src/gst-plugins/commons/kmsutils.c
+++ b/src/gst-plugins/commons/kmsutils.c
@@ -216,6 +216,9 @@ kms_utils_get_caps_codec_name_from_sdp (const gchar * codec_name)
   if (g_ascii_strcasecmp (VP8_ENCONDING_NAME, codec_name) == 0) {
     return "VP8";
   }
+  if (g_ascii_strcasecmp ("speex", codec_name) == 0) {
+    return "SPEEX";
+  }
 
   return codec_name;
 }

--- a/src/gst-plugins/commons/kmsutils.c
+++ b/src/gst-plugins/commons/kmsutils.c
@@ -216,7 +216,7 @@ kms_utils_get_caps_codec_name_from_sdp (const gchar * codec_name)
   if (g_ascii_strcasecmp (VP8_ENCONDING_NAME, codec_name) == 0) {
     return "VP8";
   }
-  if (g_ascii_strcasecmp ("speex", codec_name) == 0) {
+  if (g_ascii_strcasecmp (SPEEX_ENCONDING_NAME, codec_name) == 0) {
     return "SPEEX";
   }
 

--- a/src/server/config/SdpEndpoint.conf.json
+++ b/src/server/config/SdpEndpoint.conf.json
@@ -19,6 +19,9 @@
     },
     {
       "name" : "AMR/8000"
+    },
+    {
+      "name" : "speex/16000"
     }
   ],
   "videoCodecs" : [

--- a/src/server/implementation/objects/MediaElementImpl.cpp
+++ b/src/server/implementation/objects/MediaElementImpl.cpp
@@ -1012,6 +1012,10 @@ void MediaElementImpl::setAudioFormat (std::shared_ptr<AudioCaps> caps)
     str_caps = "audio/x-raw";
     break;
 
+  case AudioCodec::SPEEX:
+    str_caps = "audio/x-speex";
+    break;
+
   default:
     throw KurentoException (MEDIA_OBJECT_ILLEGAL_PARAM_ERROR,
                             "Invalid parameter provided: " + codec->getString() );

--- a/src/server/interface/core.kmd.json
+++ b/src/server/interface/core.kmd.json
@@ -989,7 +989,8 @@
       "values": [
         "OPUS",
         "PCMU",
-        "RAW"
+        "RAW",
+        "SPEEX"
       ],
       "name": "AudioCodec",
       "doc": "Codec used for transmission of audio."


### PR DESCRIPTION
SPEEX Codec has been custom added for kms-core 6.5.0. It can be used by mapping the SPEEX codec to your SDP file:

`speex/16000`
