### PR TITLE
Use format macros to fix compiler errors on 32bit systems.

### DIFF
--- a/src/gst-plugins/commons/rtpsync/kmsrtpsynchronizer.c
+++ b/src/gst-plugins/commons/rtpsync/kmsrtpsynchronizer.c
@@ -114,7 +114,7 @@ kms_rtp_synchronizer_new (KmsRtpSyncContext * context, gboolean feeded_sorted)
     self->priv->context = g_object_ref (context);
   } else {
     GST_WARNING_OBJECT (self,
-        "No context provided, creating new one. This syncrhonizer cannot be synced with others.");
+        "No context provided, creating new one. This synchronizer cannot be synced with others.");
     self->priv->context = kms_rtp_sync_context_new (NULL);
   }
 
@@ -189,8 +189,9 @@ kms_rtp_synchronizer_process_rtcp_packet (KmsRtpSynchronizer * self,
   KMS_RTP_SYNCHRONIZER_LOCK (self);
 
   GST_DEBUG_OBJECT (self,
-      "Received RTCP SR packet SSRC: %u, rtp_time: %u, ntp_time: %lu, ntp_ns_time: %"
-      GST_TIME_FORMAT, ssrc, rtp_time, ntp_time, GST_TIME_ARGS (ntp_ns_time));
+      "Received RTCP SR packet SSRC: %u, rtp_time: %u, ntp_time: %"
+      G_GUINT64_FORMAT ", ntp_ns_time: %" GST_TIME_FORMAT, ssrc, rtp_time,
+      ntp_time, GST_TIME_ARGS (ntp_ns_time));
 
   if (!self->priv->base_initiated) {
     kms_rtp_sync_context_get_time_matching (self->priv->context, ntp_ns_time,

--- a/src/gst-plugins/kmsaudiomixer.c
+++ b/src/gst-plugins/kmsaudiomixer.c
@@ -107,8 +107,8 @@ cb_latency (GstPad * pad, GstPadProbeInfo * info, gpointer data)
     return GST_PAD_PROBE_OK;
   }
 
-  GST_LOG_OBJECT (pad, "Modifing latency query. New latency %ld",
-      LATENCY * GST_MSECOND);
+  GST_LOG_OBJECT (pad, "Modifing latency query. New latency %" G_GUINT64_FORMAT,
+      (guint64) (LATENCY * GST_MSECOND));
 
   gst_query_set_latency (GST_PAD_PROBE_INFO_QUERY (info),
       TRUE, 0, LATENCY * GST_MSECOND);

--- a/src/server/implementation/MediaSet.cpp
+++ b/src/server/implementation/MediaSet.cpp
@@ -92,7 +92,7 @@ MediaSet::deleteMediaSet()
       cv.notify_all();
     });
 
-    GST_INFO ("Destroying %ld pipelines that are already alive", pipes.size() );
+    GST_INFO ("Destroying %zd pipelines that are already alive", pipes.size() );
 
     for (auto it : pipes) {
       mediaSet->release (it);
@@ -166,7 +166,7 @@ MediaSet::~MediaSet ()
   std::unique_lock <std::recursive_mutex> lock (recMutex);
 
   if (!objectsMap.empty() ) {
-    GST_DEBUG ("Still %lu object/s alive", objectsMap.size() );
+    GST_DEBUG ("Still %zu object/s alive", objectsMap.size() );
   }
 
   terminated = true;

--- a/tests/check/element/passthrough.c
+++ b/tests/check/element/passthrough.c
@@ -77,7 +77,7 @@ fakesink_hand_off_check_size (GstElement * fakesink, GstBuffer * buf,
     gsize bitrate = size * 8 / (count / 30);
 
     // TODO: Count for size
-    GST_INFO ("Bitrate is: %ld bits", bitrate);
+    GST_INFO ("Bitrate is: %" G_GSIZE_FORMAT " bits", bitrate);
 
     fail_if (abs ((int) ((gssize) bitrate - BITRATE)) > BITRATE * 0.15);
     g_object_set (G_OBJECT (fakesink), "signal-handoffs", FALSE, NULL);

--- a/tests/check/general/rtpsync.c
+++ b/tests/check/general/rtpsync.c
@@ -66,9 +66,9 @@ do {                                                                            
   GstBuffer *__buf;                                                                       \
                                                                                           \
   __buf = generate_rtp_buffer_full (gst_ts, ssrc, pt, seq_num, rtp_ts);                   \
-  GST_DEBUG ("in PTS: %lu", GST_BUFFER_PTS (__buf));                                      \
+  GST_DEBUG ("in PTS: %" GST_TIME_FORMAT, GST_TIME_ARGS(GST_BUFFER_PTS (__buf)));         \
   fail_func (kms_rtp_synchronizer_process_rtp_buffer (sync, __buf, NULL));                \
-  GST_DEBUG ("out PTS: %lu", GST_BUFFER_PTS (__buf));                                     \
+  GST_DEBUG ("out PTS: %" GST_TIME_FORMAT, GST_TIME_ARGS(GST_BUFFER_PTS (__buf)));        \
   fail_unless (GST_BUFFER_PTS (__buf) == expected_out_pts);                               \
   gst_buffer_unref (__buf);                                                               \
 } while (0)


### PR DESCRIPTION
Fixes errors on `i386` and `armhf`.