### PR TITLE
fix composite: kmsenctreebin.c use max-size-time instead of max-size-buffers

### DIFF
--- a/src/gst-plugins/commons/kmsenctreebin.c
+++ b/src/gst-plugins/commons/kmsenctreebin.c
@@ -26,6 +26,7 @@
 #define GST_CAT_DEFAULT kms_enc_tree_bin_debug
 GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 
+#define LEAKY_TIME 600000000    /*600 ms */
 #define kms_enc_tree_bin_parent_class parent_class
 G_DEFINE_TYPE (KmsEncTreeBin, kms_enc_tree_bin, KMS_TYPE_TREE_BIN);
 
@@ -479,7 +480,7 @@ kms_enc_tree_bin_configure (KmsEncTreeBin * self, const GstCaps * caps,
   convert = kms_utils_create_convert_for_caps (caps);
   mediator = kms_utils_create_mediator_element (caps);
   queue = gst_element_factory_make ("queue", NULL);
-  g_object_set (queue, "leaky", 2, "max-size-buffers", 1, NULL);
+  g_object_set (queue, "leaky", 2, "max-size-time", LEAKY_TIME, NULL);
 
   if (rate) {
     gst_bin_add (GST_BIN (self), rate);


### PR DESCRIPTION
Fix https://github.com/Kurento/bugtracker/issues/197

I'm not sure of the original use-case of #7 ([related mailing-list post](https://groups.google.com/d/msg/kurento/_IsI7tcdLVw/N_GB6SKLBAAJ)), so instead of reverting the queue restriction, I changed it from `max-size-buffers` to `max-size-time` ([also used in agnosticbin](https://github.com/Kurento/kms-core/blob/495b7daa84201294d24d56c98e4a0223e12faad5/src/gst-plugins/kmsagnosticbin.c#L421)).  The composite works as expected again (no audio glitches).

@kc7bfi Does this still change still apply to your issue?

Follows: https://github.com/Kurento/kms-core/pull/7