### PR TITLE
Change MP4 recorder audio codec from MP3 to AAC

### DIFF
--- a/src/gst-plugins/commons/kmsrecordingprofile.c
+++ b/src/gst-plugins/commons/kmsrecordingprofile.c
@@ -66,7 +66,7 @@ kms_recording_profile_create_mp4_profile (gboolean has_audio,
   gst_caps_unref (pc);
 
   if (has_audio) {
-    GstCaps *ac = gst_caps_from_string ("audio/mpeg,mpegversion=1,layer=3");
+    GstCaps *ac = gst_caps_from_string ("audio/mpeg,mpegversion=4");
 
     gst_encoding_container_profile_add_profile (cprof, (GstEncodingProfile *)
         gst_encoding_audio_profile_new (ac, NULL, NULL, 0));


### PR DESCRIPTION
Hey Team,

MP4 video recording for Kurento has an issue like when we try to play recorded mp4 video in Safari browser, it doesn't play audio. Looks like audio is codec wasn't right. I was able to get it working by changing the audio codec version of mp4 to mpegversion 4. Please review it and accept my pull request.