### PR TITLE
Remove audio delay/pause when connecting new endpoints to composite

### DIFF
--- a/src/gst-plugins/kmsagnosticbin.c
+++ b/src/gst-plugins/kmsagnosticbin.c
@@ -430,9 +430,7 @@ kms_agnostic_bin2_link_to_tee (KmsAgnosticBin2 * self, GstPad * pad,
     GstElement *rate = kms_utils_create_rate_for_caps (caps);
     GstElement *mediator = kms_utils_create_mediator_element (caps);
 
-    if (kms_utils_caps_is_video (caps)) {
-      g_object_set (queue, "leaky", 2, "max-size-time", LEAKY_TIME, NULL);
-    }
+    g_object_set (queue, "leaky", 2, "max-size-time", LEAKY_TIME, NULL);
 
     remove_element_on_unlinked (convert, "src", "sink");
     if (rate) {

--- a/src/gst-plugins/kmsaudiomixer.c
+++ b/src/gst-plugins/kmsaudiomixer.c
@@ -830,7 +830,8 @@ kms_audio_mixer_add_src_pad (KmsAudioMixer * self, const char *padname)
 
   g_object_set (tee, "allow-not-linked", TRUE, NULL);
   g_object_set (fakesink, "sync", FALSE, "async", FALSE, NULL);
-  g_object_set (adder, "latency", LATENCY * GST_MSECOND, NULL);
+  g_object_set (adder, "latency", LATENCY * GST_MSECOND, "start-time-selection",
+    1, NULL);
 
   g_object_set_qdata_full (G_OBJECT (adder), key_sink_pad_name_quark (),
       g_strdup (padname), g_free);


### PR DESCRIPTION
The idea is to use the start time of the first buffer as the start time of audiomixer (and not the default, 0), avoiding it to produce silence from 0 to the current running time.

Fixes https://github.com/Kurento/bugtracker/issues/146
Closes https://github.com/Kurento/kms-core/pull/10