### PR TITLE
Fixed config-interval prop type checking in basertpendpoint and rtppaytreebin

### DIFF
--- a/src/gst-plugins/commons/kmsbasertpendpoint.c
+++ b/src/gst-plugins/commons/kmsbasertpendpoint.c
@@ -1218,7 +1218,7 @@ kms_base_rtp_endpoint_get_payloader_for_caps (GstCaps * caps)
   pspec =
       g_object_class_find_property (G_OBJECT_GET_CLASS (payloader),
       "config-interval");
-  if (pspec != NULL && G_PARAM_SPEC_VALUE_TYPE (pspec) == G_TYPE_UINT) {
+  if (pspec != NULL && G_PARAM_SPEC_VALUE_TYPE (pspec) == G_TYPE_INT) {
     g_object_set (payloader, "config-interval", 1, NULL);
   }
 

--- a/src/gst-plugins/commons/kmsrtppaytreebin.c
+++ b/src/gst-plugins/commons/kmsrtppaytreebin.c
@@ -61,7 +61,7 @@ create_payloader_for_caps (const GstCaps * caps)
     pspec =
         g_object_class_find_property (G_OBJECT_GET_CLASS (payloader),
         "config-interval");
-    if (pspec != NULL && G_PARAM_SPEC_VALUE_TYPE (pspec) == G_TYPE_UINT) {
+    if (pspec != NULL && G_PARAM_SPEC_VALUE_TYPE (pspec) == G_TYPE_INT) {
       g_object_set (payloader, "config-interval", 1, NULL);
     }
 


### PR DESCRIPTION
The property was changed from type G_UINT to G_INT (to support the value -1 for SPS/PPS at every IDR slice), but the proptype checking in `kmsbasertpendpoint` and `kmsrtppaytreebin` were not updated accordingly, so it was basically a no-op.

Reference:
https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gst-plugins-good/html/gst-plugins-good-plugins-rtph264pay.html  at `config-interval` and https://lists.freedesktop.org/archives/gstreamer-commits/2016-June/094714.html.


