### PR TITLE
Fix MediaFlowInStateChange crash: Lock mutex around calls to sigc++

### DIFF
--- a/src/server/implementation/objects/BaseRtpEndpointImpl.cpp
+++ b/src/server/implementation/objects/BaseRtpEndpointImpl.cpp
@@ -143,6 +143,7 @@ BaseRtpEndpointImpl::updateMediaState (guint new_state)
     MediaStateChanged event (shared_from_this(),
                              MediaStateChanged::getName (), old_state, current_media_state);
 
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     this->signalMediaStateChanged (event);
   }
 }
@@ -174,7 +175,8 @@ BaseRtpEndpointImpl::updateConnectionState (gchar *sessId, guint new_state)
     ConnectionStateChanged event (shared_from_this(),
                                   ConnectionStateChanged::getName (), old_state, current_conn_state);
 
-    this->signalConnectionStateChanged (event);
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
+    signalConnectionStateChanged (event);
   }
 }
 

--- a/src/server/implementation/objects/BaseRtpEndpointImpl.cpp
+++ b/src/server/implementation/objects/BaseRtpEndpointImpl.cpp
@@ -143,8 +143,7 @@ BaseRtpEndpointImpl::updateMediaState (guint new_state)
     MediaStateChanged event (shared_from_this(),
                              MediaStateChanged::getName (), old_state, current_media_state);
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    this->signalMediaStateChanged (event);
+    sigcSignalEmit(signalMediaStateChanged, event);
   }
 }
 
@@ -175,8 +174,7 @@ BaseRtpEndpointImpl::updateConnectionState (gchar *sessId, guint new_state)
     ConnectionStateChanged event (shared_from_this(),
                                   ConnectionStateChanged::getName (), old_state, current_conn_state);
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalConnectionStateChanged (event);
+    sigcSignalEmit(signalConnectionStateChanged, event);
   }
 }
 

--- a/src/server/implementation/objects/MediaElementImpl.cpp
+++ b/src/server/implementation/objects/MediaElementImpl.cpp
@@ -479,6 +479,8 @@ MediaElementImpl::mediaFlowOutStateChange (gboolean isFlowing, gchar *padName,
     MediaFlowOutStateChange event (shared_from_this(),
                                    MediaFlowOutStateChange::getName (),
                                    state, padName, padTypeToMediaType (type));
+
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     signalMediaFlowOutStateChange (event);
   } catch (std::bad_weak_ptr &e) {
   }
@@ -511,6 +513,8 @@ MediaElementImpl::mediaFlowInStateChange (gboolean isFlowing, gchar *padName,
     MediaFlowInStateChange event (shared_from_this(),
                                   MediaFlowInStateChange::getName (),
                                   state, padName, padTypeToMediaType (type));
+
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     signalMediaFlowInStateChange (event);
   } catch (std::bad_weak_ptr &e) {
   }
@@ -545,6 +549,8 @@ MediaElementImpl::onMediaTranscodingStateChange (gboolean isTranscoding,
     MediaTranscodingStateChange event (shared_from_this(),
                                        MediaTranscodingStateChange::getName (),
                                        state, binName, padTypeToMediaType (type));
+
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     signalMediaTranscodingStateChange (event);
   } catch (std::bad_weak_ptr &e) {
     GST_WARNING_OBJECT (element, "Cannot emit event: MediaTranscodingStateChange");
@@ -948,6 +954,8 @@ void MediaElementImpl::connect (std::shared_ptr<MediaElement> sink,
                                      ElementConnected::getName (),
                                      sink, mediaType, sourceMediaDescription,
                                      sinkMediaDescription);
+
+  std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
   signalElementConnected (elementConnected);
 }
 
@@ -1068,6 +1076,8 @@ void MediaElementImpl::disconnect (std::shared_ptr<MediaElement> sink,
       ElementDisconnected::getName (),
       sink, mediaType, sourceMediaDescription,
       sinkMediaDescription);
+
+  std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
   signalElementDisconnected (elementDisconnected);
 }
 

--- a/src/server/implementation/objects/MediaElementImpl.cpp
+++ b/src/server/implementation/objects/MediaElementImpl.cpp
@@ -480,8 +480,7 @@ MediaElementImpl::mediaFlowOutStateChange (gboolean isFlowing, gchar *padName,
                                    MediaFlowOutStateChange::getName (),
                                    state, padName, padTypeToMediaType (type));
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalMediaFlowOutStateChange (event);
+    sigcSignalEmit(signalMediaFlowOutStateChange, event);
   } catch (std::bad_weak_ptr &e) {
   }
 }
@@ -514,8 +513,7 @@ MediaElementImpl::mediaFlowInStateChange (gboolean isFlowing, gchar *padName,
                                   MediaFlowInStateChange::getName (),
                                   state, padName, padTypeToMediaType (type));
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalMediaFlowInStateChange (event);
+    sigcSignalEmit(signalMediaFlowInStateChange, event);
   } catch (std::bad_weak_ptr &e) {
   }
 }
@@ -550,8 +548,7 @@ MediaElementImpl::onMediaTranscodingStateChange (gboolean isTranscoding,
                                        MediaTranscodingStateChange::getName (),
                                        state, binName, padTypeToMediaType (type));
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalMediaTranscodingStateChange (event);
+    sigcSignalEmit(signalMediaTranscodingStateChange, event);
   } catch (std::bad_weak_ptr &e) {
     GST_WARNING_OBJECT (element, "Cannot emit event: MediaTranscodingStateChange");
   }
@@ -950,13 +947,12 @@ void MediaElementImpl::connect (std::shared_ptr<MediaElement> sink,
   sinkLock.unlock();
   lock.unlock ();
 
-  ElementConnected elementConnected (shared_from_this(),
+  ElementConnected event (shared_from_this(),
                                      ElementConnected::getName (),
                                      sink, mediaType, sourceMediaDescription,
                                      sinkMediaDescription);
 
-  std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-  signalElementConnected (elementConnected);
+  sigcSignalEmit(signalElementConnected, event);
 }
 
 void
@@ -1072,13 +1068,12 @@ void MediaElementImpl::disconnect (std::shared_ptr<MediaElement> sink,
   sinkLock.unlock();
   lock.unlock ();
 
-  ElementDisconnected elementDisconnected (shared_from_this(),
+  ElementDisconnected event (shared_from_this(),
       ElementDisconnected::getName (),
       sink, mediaType, sourceMediaDescription,
       sinkMediaDescription);
 
-  std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-  signalElementDisconnected (elementDisconnected);
+  sigcSignalEmit(signalElementDisconnected, event);
 }
 
 void MediaElementImpl::setAudioFormat (std::shared_ptr<AudioCaps> caps)

--- a/src/server/implementation/objects/MediaObjectImpl.hpp
+++ b/src/server/implementation/objects/MediaObjectImpl.hpp
@@ -173,6 +173,8 @@ protected:
 
   const boost::property_tree::ptree &config;
 
+  std::recursive_mutex sigcMutex;
+
 private:
 
   std::string initialId;

--- a/src/server/implementation/objects/MediaObjectImpl.hpp
+++ b/src/server/implementation/objects/MediaObjectImpl.hpp
@@ -165,6 +165,16 @@ protected:
     return true;
   }
 
+  template <class T>
+  void sigcSignalEmit (const sigc::signal<void, T> &sigcSignal,
+      const RaiseBase &event)
+  {
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
+    sigcSignal.emit (dynamic_cast <const T&> (event));
+  }
+
+  std::recursive_mutex sigcMutex;
+
   /*
    * This method is intented to perform initialization actions that require
    * a call to shared_from_this ()
@@ -172,8 +182,6 @@ protected:
   virtual void postConstructor ();
 
   const boost::property_tree::ptree &config;
-
-  std::recursive_mutex sigcMutex;
 
 private:
 

--- a/src/server/implementation/objects/MediaPipelineImpl.cpp
+++ b/src/server/implementation/objects/MediaPipelineImpl.cpp
@@ -81,6 +81,7 @@ MediaPipelineImpl::processBusMessage (GstMessage *msg)
     Error error (shared_from_this(), errorMessage, code,
                  "UNEXPECTED_PIPELINE_ERROR");
 
+    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
     signalError (error);
   } catch (std::bad_weak_ptr &e) {
   }

--- a/src/server/implementation/objects/MediaPipelineImpl.cpp
+++ b/src/server/implementation/objects/MediaPipelineImpl.cpp
@@ -78,11 +78,10 @@ MediaPipelineImpl::processBusMessage (GstMessage *msg)
 
   try {
     gint code = err_code;
-    Error error (shared_from_this(), errorMessage, code,
+    Error event (shared_from_this(), errorMessage, code,
                  "UNEXPECTED_PIPELINE_ERROR");
 
-    std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-    signalError (error);
+    sigcSignalEmit(signalError, event);
   } catch (std::bad_weak_ptr &e) {
   }
 

--- a/src/server/implementation/objects/UriEndpointImpl.cpp
+++ b/src/server/implementation/objects/UriEndpointImpl.cpp
@@ -212,6 +212,8 @@ UriEndpointImpl::stateChanged (guint new_state)
 
   UriEndpointStateChanged event (shared_from_this(),
                                  UriEndpointStateChanged::getName(), state);
+
+  std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
   signalUriEndpointStateChanged (event);
 }
 

--- a/src/server/implementation/objects/UriEndpointImpl.cpp
+++ b/src/server/implementation/objects/UriEndpointImpl.cpp
@@ -213,8 +213,7 @@ UriEndpointImpl::stateChanged (guint new_state)
   UriEndpointStateChanged event (shared_from_this(),
                                  UriEndpointStateChanged::getName(), state);
 
-  std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-  signalUriEndpointStateChanged (event);
+  sigcSignalEmit(signalUriEndpointStateChanged, event);
 }
 
 UriEndpointImpl::StaticConstructor UriEndpointImpl::staticConstructor;


### PR DESCRIPTION
libsigc++ signal/slot mechanism is *not thread-safe*. All signal emitters must coordinate with a mutex, or else multiple threads might try to emit at the same time, breaking the library.

Repos:
* Kurento/kms-core#19
* Kurento/kms-elements#19
* Kurento/kms-filters#4

Fixes Kurento/bugtracker#393