### PR TITLE
Add offerToReceiveAudio/Video options to SdpEndpoint.generateOffer()

### DIFF
--- a/src/server/implementation/objects/SdpEndpointImpl.cpp
+++ b/src/server/implementation/objects/SdpEndpointImpl.cpp
@@ -189,6 +189,16 @@ void SdpEndpointImpl::setMaxAudioRecvBandwidth (int maxAudioRecvBandwidth)
 
 std::string SdpEndpointImpl::generateOffer ()
 {
+  std::shared_ptr<OfferOptions> options = std::make_shared <OfferOptions> ();
+
+  options->setOfferToReceiveAudio(true);
+  options->setOfferToReceiveVideo(true);
+
+  return generateOffer(options);
+}
+
+std::string SdpEndpointImpl::generateOffer (std::shared_ptr<OfferOptions> options)
+{
   GstSDPMessage *offer = nullptr;
   std::string offerStr;
   bool expected = false;
@@ -197,6 +207,16 @@ std::string SdpEndpointImpl::generateOffer ()
     //the endpoint is already negotiated
     throw KurentoException (SDP_END_POINT_ALREADY_NEGOTIATED,
                             "Endpoint already negotiated");
+  }
+
+  if (options->isSetOfferToReceiveAudio ()
+      && !options->getOfferToReceiveAudio ()) {
+    g_object_set (element, "num-audio-medias", 0, NULL);
+  }
+
+  if (options->isSetOfferToReceiveVideo ()
+      && !options->getOfferToReceiveVideo ()) {
+    g_object_set (element, "num-video-medias", 0, NULL);
   }
 
   g_signal_emit_by_name (element, "generate-offer", sessId.c_str (), &offer);

--- a/src/server/implementation/objects/SdpEndpointImpl.hpp
+++ b/src/server/implementation/objects/SdpEndpointImpl.hpp
@@ -19,6 +19,7 @@
 
 #include "SessionEndpointImpl.hpp"
 #include "SdpEndpoint.hpp"
+#include <OfferOptions.hpp>
 #include <EventHandler.hpp>
 #include <atomic>
 
@@ -45,7 +46,9 @@ public:
   void setMaxVideoRecvBandwidth (int maxVideoRecvBandwidth) override;
   int getMaxAudioRecvBandwidth () override;
   void setMaxAudioRecvBandwidth (int maxAudioRecvBandwidth) override;
+
   std::string generateOffer () override;
+  std::string generateOffer (std::shared_ptr<OfferOptions> options) override;
   std::string processOffer (const std::string &offer) override;
   std::string processAnswer (const std::string &answer) override;
   std::string getLocalSessionDescriptor () override;

--- a/src/server/interface/core.kmd.json
+++ b/src/server/interface/core.kmd.json
@@ -493,9 +493,8 @@ It offers the methods needed to control the creation and connection of elements 
       "name": "SdpEndpoint",
       "abstract": true,
       "extends": "SessionEndpoint",
-      "doc": "Interface implemented by Endpoints that require an SDP negotiation for the setup
-of a networked media session with remote peers.
-<p>The API provides the following functionality:</p>
+      "doc": "Interface implemented by Endpoints that require an SDP Offer/Answer negotiation in order to configure a media session.
+<p>Functionality provided by this API:</p>
 <ul>
   <li>Generate SDP offers.</li>
   <li>Process SDP offers.</li>
@@ -557,7 +556,14 @@ Throws:
   </li>
 </ul>
           ",
-          "params": [],
+          "params": [
+            {
+              "name": "options",
+              "doc": "An <code>OfferOptions</code> providing options requested for the offer.",
+              "type": "OfferOptions",
+              "optional": true
+            }
+          ],
           "return": {
             "doc": "The SDP offer.",
             "type": "String"
@@ -2359,6 +2365,27 @@ If the negotiation process is not complete, it will return NULL.
           "type": "int",
           "optional":true,
           "defaultValue": 300000
+        }
+      ]
+    },
+    {
+      "typeFormat": "REGISTER",
+      "name": "OfferOptions",
+      "doc": "Used to customize the offer created by <code>SdpEndpoint.generateOffer</code>.",
+      "properties": [
+        {
+          "name": "offerToReceiveAudio",
+          "doc": "Whether or not to offer to the remote peer the opportunity to send audio.",
+          "type": "boolean",
+          "optional": true,
+          "defaultValue": true
+        },
+        {
+          "name": "offerToReceiveVideo",
+          "doc": "Whether or not to offer to the remote peer the opportunity to send video.",
+          "type": "boolean",
+          "optional": true,
+          "defaultValue": true
         }
       ]
     }


### PR DESCRIPTION
<!--
Thank you for your contribution to the Kurento project.
Please provide enough information so that others can review your Pull Request.

For more information, see the Contribution Guidelines:
https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md
-->


## What is the current behavior you want to change?
`SdpEndpoint.generateOffer()` always generates an audio+video offer, without giving a chance to have a video-only or audio-only offer.


## What is the new behavior provided by this change?
Add `offerToReceiveAudio`, `offerToReceiveVideo` options to `SdpEndpoint.generateOffer()`

These mimic the behavior of RTCPeerConnection API:
https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createOffer

Sample usage, for an audio-only offer:

```
import org.kurento.client.OfferOptions;
[...]

OfferOptions options = new OfferOptions();
options.setOfferToReceiveAudio(true);
options.setOfferToReceiveVideo(false);

String sdpOffer = webRtcEp.generateOffer(options);
```


## How has this been tested?
Modified kurento-hello-world to generate SDP offers from Kurento. Pending tests, that will be added after the implementation is seen to work.


## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [x] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
