### PR TITLE
basertpendpoint: add externalIPv4 and externalIPv6 parameters

### DIFF
--- a/src/server/config/BaseRtpEndpoint.conf.ini
+++ b/src/server/config/BaseRtpEndpoint.conf.ini
@@ -40,3 +40,15 @@
 ;; * Unit: Bytes.
 ;; * Default: 1200.
 ;mtu=1200
+
+;; External IPv4 and IPv6 addresses of the media server.
+;;
+;; Forces the stack to use a specific address.
+;;
+;; If not specified then an address is selected at random.
+;;
+;; <externalIPv4> is a single IPv4 address.
+;; <externalIPv6> is a single IPv6 address.
+;;
+;externalIPv4=198.51.100.1
+;externalIPv6=2001:0db8:85a3:0000:0000:8a2e:0370:7334

--- a/src/server/implementation/objects/BaseRtpEndpointImpl.cpp
+++ b/src/server/implementation/objects/BaseRtpEndpointImpl.cpp
@@ -50,10 +50,14 @@ GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 #define PARAM_MIN_PORT "minPort"
 #define PARAM_MAX_PORT "maxPort"
 #define PARAM_MTU "mtu"
+#define PARAM_EXTERNAL_IPV4 "externalIPv4"
+#define PARAM_EXTERNAL_IPV6 "externalIPv6"
 
 #define PROP_MIN_PORT "min-port"
 #define PROP_MAX_PORT "max-port"
 #define PROP_MTU "mtu"
+#define PROP_EXTERNAL_IPV4 "external-ipv4"
+#define PROP_EXTERNAL_IPV6 "external-ipv6"
 
 /* Fixed point conversion macros */
 #define FRIC        65536.                  /* 2^16 as a double */
@@ -97,21 +101,48 @@ BaseRtpEndpointImpl::BaseRtpEndpointImpl (const boost::property_tree::ptree
   connStateChangedHandlerId = 0;
 
   guint minPort = 0;
-  if (getConfigValue<guint, BaseRtpEndpoint> (&minPort, PARAM_MIN_PORT)) {
+
+  if (getConfigValue<guint, BaseRtpEndpoint> (&minPort, PARAM_MIN_PORT) ) {
     g_object_set (getGstreamerElement (), PROP_MIN_PORT, minPort, NULL);
   }
 
   guint maxPort = 0;
-  if (getConfigValue <guint, BaseRtpEndpoint> (&maxPort, PARAM_MAX_PORT)) {
+
+  if (getConfigValue <guint, BaseRtpEndpoint> (&maxPort, PARAM_MAX_PORT) ) {
     g_object_set (getGstreamerElement (), PROP_MAX_PORT, maxPort, NULL);
   }
 
   guint mtu;
-  if (getConfigValue <guint, BaseRtpEndpoint> (&mtu, PARAM_MTU)) {
+
+  if (getConfigValue <guint, BaseRtpEndpoint> (&mtu, PARAM_MTU) ) {
     GST_INFO ("Predefined RTP MTU: %u", mtu);
     g_object_set (G_OBJECT (element), PROP_MTU, mtu, NULL);
   } else {
     GST_DEBUG ("No predefined RTP MTU found in config; using default");
+  }
+
+  std::string externalIPv4;
+
+  if (getConfigValue <std::string, BaseRtpEndpoint> (&externalIPv4,
+      PARAM_EXTERNAL_IPV4) ) {
+    GST_INFO ("Predefined external IPv4 address: %s", externalIPv4.c_str() );
+    g_object_set (G_OBJECT (element), PROP_EXTERNAL_IPV4,
+                  externalIPv4.c_str(), NULL);
+  } else {
+    GST_DEBUG ("No predefined external IPv4 address found in config;"
+               " you can set one or default to random selection");
+  }
+
+  std::string externalIPv6;
+
+  if (getConfigValue <std::string, BaseRtpEndpoint> (&externalIPv6,
+      PARAM_EXTERNAL_IPV6) ) {
+    GST_INFO ("Predefined external IPv6 address: %s", externalIPv6.c_str() );
+    g_object_set (G_OBJECT (element), PROP_EXTERNAL_IPV6,
+                  externalIPv6.c_str(), NULL);
+  } else {
+    GST_DEBUG ("No predefined external IPv6 address found in config;"
+               " you can set one or default to random selection");
   }
 }
 
@@ -150,15 +181,16 @@ BaseRtpEndpointImpl::updateMediaState (guint new_state)
 
   if (old_state->getValue() != current_media_state->getValue() ) {
     GST_DEBUG_OBJECT (element, "MediaState changed to '%s'",
-        current_media_state->getString().c_str());
+                      current_media_state->getString().c_str() );
+
     try {
       MediaStateChanged event (shared_from_this (),
-          MediaStateChanged::getName (), old_state, current_media_state);
-      sigcSignalEmit(signalMediaStateChanged, event);
+                               MediaStateChanged::getName (), old_state, current_media_state);
+      sigcSignalEmit (signalMediaStateChanged, event);
     } catch (const std::bad_weak_ptr &e) {
       // shared_from_this()
       GST_ERROR ("BUG creating %s: %s", MediaStateChanged::getName ().c_str (),
-          e.what ());
+                 e.what () );
     }
   }
 }
@@ -187,15 +219,16 @@ BaseRtpEndpointImpl::updateConnectionState (gchar *sessId, guint new_state)
 
   if (old_state->getValue() != current_conn_state->getValue() ) {
     GST_DEBUG_OBJECT (element, "ConnectionState changed to '%s'",
-        current_conn_state->getString().c_str());
+                      current_conn_state->getString().c_str() );
+
     try {
       ConnectionStateChanged event (shared_from_this(),
-          ConnectionStateChanged::getName (), old_state, current_conn_state);
-      sigcSignalEmit(signalConnectionStateChanged, event);
+                                    ConnectionStateChanged::getName (), old_state, current_conn_state);
+      sigcSignalEmit (signalConnectionStateChanged, event);
     } catch (const std::bad_weak_ptr &e) {
       // shared_from_this()
       GST_ERROR ("BUG creating %s: %s",
-          ConnectionStateChanged::getName ().c_str (), e.what ());
+                 ConnectionStateChanged::getName ().c_str (), e.what () );
     }
   }
 }
@@ -391,6 +424,54 @@ BaseRtpEndpointImpl::setMtu (int mtu)
 {
   GST_INFO ("Set MTU for RTP: %d", mtu);
   g_object_set (G_OBJECT (element), PROP_MTU, mtu, NULL);
+}
+
+std::string
+BaseRtpEndpointImpl::getExternalIPv4 ()
+{
+  std::string externalIPv4;
+  gchar *ret;
+
+  g_object_get (G_OBJECT (element), PROP_EXTERNAL_IPV4, &ret, NULL);
+
+  if (ret != nullptr) {
+    externalIPv4 = std::string (ret);
+    g_free (ret);
+  }
+
+  return externalIPv4;
+}
+
+void
+BaseRtpEndpointImpl::setExternalIPv4 (const std::string &externalIPv4)
+{
+  GST_INFO ("Set external IPv4 address: %s", externalIPv4.c_str() );
+  g_object_set (G_OBJECT (element), PROP_EXTERNAL_IPV4,
+                externalIPv4.c_str(), NULL);
+}
+
+std::string
+BaseRtpEndpointImpl::getExternalIPv6 ()
+{
+  std::string externalIPv6;
+  gchar *ret;
+
+  g_object_get (G_OBJECT (element), PROP_EXTERNAL_IPV6, &ret, NULL);
+
+  if (ret != nullptr) {
+    externalIPv6 = std::string (ret);
+    g_free (ret);
+  }
+
+  return externalIPv6;
+}
+
+void
+BaseRtpEndpointImpl::setExternalIPv6 (const std::string &externalIPv6)
+{
+  GST_INFO ("Set external IPv6 address: %s", externalIPv6.c_str() );
+  g_object_set (G_OBJECT (element), PROP_EXTERNAL_IPV6,
+                externalIPv6.c_str(), NULL);
 }
 
 /******************/
@@ -612,9 +693,9 @@ setDeprecatedProperties (std::shared_ptr<EndpointStats> eStats)
 
   for (auto &inStat : inStats) {
     if (inStat->getName() == "sink_audio_default") {
-      eStats->setAudioE2ELatency(inStat->getAvg());
+      eStats->setAudioE2ELatency (inStat->getAvg() );
     } else if (inStat->getName() == "sink_video_default") {
-      eStats->setVideoE2ELatency(inStat->getAvg());
+      eStats->setVideoE2ELatency (inStat->getAvg() );
     }
   }
 }

--- a/src/server/implementation/objects/BaseRtpEndpointImpl.hpp
+++ b/src/server/implementation/objects/BaseRtpEndpointImpl.hpp
@@ -67,6 +67,12 @@ public:
   virtual int getMtu ();
   virtual void setMtu (int mtu);
 
+  virtual std::string getExternalIPv4 ();
+  virtual void setExternalIPv4 (const std::string &externalIPv4);
+
+  virtual std::string getExternalIPv6 ();
+  virtual void setExternalIPv6 (const std::string &externalIPv6);
+
   sigc::signal<void, MediaStateChanged> signalMediaStateChanged;
   sigc::signal<void, ConnectionStateChanged> signalConnectionStateChanged;
 


### PR DESCRIPTION


<!--
Thank you for your contribution to the Kurento project.
Please provide enough information so that others can review your Pull Request.

For more information, see the Contribution Guidelines:
https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md
-->


## What is the current behavior you want to change?
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->


## What is the new behavior provided by this change?

RTP endpoint currently selects the media IP address in a random manner.

On a multi-homed host this can be problematic.

<!--
Example: "Adding a function to do X",
then explain why it is necessary to have a way to do X.
-->


## How has this been tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, tests ran to see how
your change affects other areas of the code, etc.
-->

Testing with my reConServer / reSIProcate / Kurento integration branch


## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] My change requires a change to the documentation
- [x] My change requires a change in other repository <!-- Explain which one --> kms-elements pull request submitted


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [x] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
