### PR TITLE
MediaElement: Add "TargetEncoderBitrate" property + Min/Max family

### DIFF
--- a/src/gst-plugins/commons/kmsbasertpendpoint.c
+++ b/src/gst-plugins/commons/kmsbasertpendpoint.c
@@ -221,7 +221,6 @@ struct _KmsBaseRtpEndpointPrivate
   RtpMediaConfig *audio_config;
   RtpMediaConfig *video_config;
 
-  gint32 target_bitrate;
   guint min_video_recv_bw;
   guint min_video_send_bw;
   guint max_video_send_bw;
@@ -272,7 +271,6 @@ static guint obj_signals[LAST_SIGNAL] = { 0 };
 #define DEFAULT_RTCP_MUX    FALSE
 #define DEFAULT_RTCP_NACK    FALSE
 #define DEFAULT_RTCP_REMB    FALSE
-#define DEFAULT_TARGET_BITRATE    0
 #define MIN_VIDEO_RECV_BW_DEFAULT 0
 #define MIN_VIDEO_SEND_BW_DEFAULT 100  // kbps
 #define MAX_VIDEO_SEND_BW_DEFAULT 500  // kbps
@@ -284,7 +282,6 @@ enum
   PROP_RTCP_MUX,
   PROP_RTCP_NACK,
   PROP_RTCP_REMB,
-  PROP_TARGET_BITRATE,
   PROP_MIN_VIDEO_RECV_BW,
   PROP_MIN_VIDEO_SEND_BW,
   PROP_MAX_VIDEO_SEND_BW,
@@ -2429,9 +2426,6 @@ kms_base_rtp_endpoint_set_property (GObject * object, guint property_id,
     case PROP_RTCP_REMB:
       self->priv->rtcp_remb = g_value_get_boolean (value);
       break;
-    case PROP_TARGET_BITRATE:
-      self->priv->target_bitrate = g_value_get_int (value);
-      break;
     case PROP_MIN_VIDEO_RECV_BW:{
       guint v = g_value_get_uint (value);
 
@@ -2554,9 +2548,6 @@ kms_base_rtp_endpoint_get_property (GObject * object, guint property_id,
       break;
     case PROP_RTCP_REMB:
       g_value_set_boolean (value, self->priv->rtcp_remb);
-      break;
-    case PROP_TARGET_BITRATE:
-      g_value_set_int (value, self->priv->target_bitrate);
       break;
     case PROP_MIN_VIDEO_RECV_BW:
       g_value_set_uint (value, self->priv->min_video_recv_bw);
@@ -3002,11 +2993,6 @@ kms_base_rtp_endpoint_class_init (KmsBaseRtpEndpointClass * klass)
       g_param_spec_boolean ("rtcp-remb", "RTCP REMB",
           "RTCP REMB", DEFAULT_RTCP_REMB,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property (object_class, PROP_TARGET_BITRATE,
-      g_param_spec_int ("target-bitrate", "Target bitrate",
-          "Target bitrate (bps)", 0, G_MAXINT,
-          DEFAULT_TARGET_BITRATE, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (object_class, PROP_MIN_VIDEO_RECV_BW,
       g_param_spec_uint ("min-video-recv-bandwidth",

--- a/src/server/config/MediaElement.conf.ini
+++ b/src/server/config/MediaElement.conf.ini
@@ -1,1 +1,58 @@
-;outputBitrate=1500000
+;; Target video bitrate for media transcoding.
+;;
+;; The bitrate of a video has a direct impact on its perceived image quality.
+;; Higher bitrate means higher quality, but also a larger amount of bytes to
+;; transmit or store. Use this parameter to set the desired average bitrate in
+;; videos that are transcoded by the media server.
+;;
+;; This parameter is most useful for RecorderEndpoint and RtpEndpoint: when
+;; media is being transcoded (either for streaming or storing on disk), the
+;; resulting quality is directly controlled with this value.
+;;
+;; For WebRtcEndpoint, this value should be left as default, as remote WebRTC
+;; receivers will already send feedback to inform the media server about what is
+;; the optimal bitrate to send.
+;;
+;; Setting a value will only work if done before the media starts to flow.
+;;
+;; * Unit: bps (bits per second).
+;; * Default: 300000 (300 kbps).
+;encoderBitrate=300000
+
+;; Minimum video bitrate for media transcoding.
+;;
+;; This parameter can be used to fine tune the automatic bitrate selection that
+;; normally takes place within elements that are able to dynamically change the
+;; encoding bitrate according to the conditions of the streaming, such as
+;; WebRtcEndpoint.
+;;
+;; This should be left as default in most cases, given that remote WebRTC
+;; receivers already send feedback to inform the media server about what is the
+;; optimal bitrate to send. Otherwise, this parameter could be used for example
+;; to force a higher bitrate than what is being requested by receivers.
+;;
+;; Setting a value will only work if done before the media starts to flow.
+;;
+;; * Unit: bps (bits per second).
+;; * Default: 0.
+;minEncoderBitrate=0
+
+;; Maximum video bitrate for media transcoding.
+;;
+;; This parameter can be used to fine tune the automatic bitrate selection that
+;; normally takes place within elements that are able to dynamically change the
+;; encoding bitrate according to the conditions of the streaming, such as
+;; WebRtcEndpoint.
+;;
+;; This should be left as default in most cases, given that remote WebRTC
+;; receivers already send feedback to inform the media server about what is the
+;; optimal bitrate to send. Otherwise, this parameter could be used for example
+;; to limit the total bitrate that is handled by the server, by setting a low
+;; maximum output for all endpoints.
+;;
+;; Setting a value will only work if done before the media starts to flow.
+;;
+;; * Unit: bps (bits per second).
+;; * Default: 0.
+;; * 0 = unlimited. Encoding performed with bitrate as requested by receivers.
+;maxEncoderBitrate=0

--- a/src/server/implementation/objects/MediaElementImpl.hpp
+++ b/src/server/implementation/objects/MediaElementImpl.hpp
@@ -129,6 +129,15 @@ public:
   bool isMediaTranscoding (std::shared_ptr<MediaType> mediaType,
                            const std::string &binName) override;
 
+  virtual int getEncoderBitrate () override;
+  virtual void setEncoderBitrate (int encoderBitrate) override;
+
+  virtual int getMinEncoderBitrate () override;
+  virtual void setMinEncoderBitrate (int minEncoderBitrate) override;
+
+  virtual int getMaxEncoderBitrate () override;
+  virtual void setMaxEncoderBitrate (int maxEncoderBitrate) override;
+
   virtual int getMinOuputBitrate () override;
   virtual void setMinOuputBitrate (int minOuputBitrate) override;
 

--- a/src/server/interface/core.kmd.json
+++ b/src/server/interface/core.kmd.json
@@ -1225,11 +1225,13 @@ Pipeline, towards the associated producer. Only valid for video consumers.
         },
         {
           "name": "setOutputBitrate",
-          "doc": "@deprecated\nAllows change the target bitrate for the media output, if the media is encoded using VP8 or H264. This method only works if it is called before the media starts to flow.",
+          "doc": "Set the target video bitrate for media transcoding.
+@deprecated Use :rom:attr:`encoderBitrate` instead of this method.
+          ",
           "params": [
             {
               "name": "bitrate",
-              "doc": "Configure the enconding media bitrate in bps",
+              "doc": "Target video bitrate for media transcoding.",
               "type": "int"
             }
           ]
@@ -1320,14 +1322,67 @@ Pipeline, towards the associated producer. Only valid for video consumers.
       ],
       "properties": [
         {
+          "name": "encoderBitrate",
+          "doc": "Target video bitrate for media transcoding.
+<p>
+  The bitrate of a video has a direct impact on its perceived image quality.
+  Higher bitrate means higher quality, but also a larger amount of bytes to
+  transmit or store. Use this parameter to set the desired average bitrate in
+  videos that are transcoded by the media server.
+</p>
+<p>
+  This parameter is most useful for :rom:cls:`RecorderEndpoint` and
+  :rom:cls:`RtpEndpoint`: when media is being transcoded (either for streaming
+  or storing on disk), the resulting quality is directly controlled with this
+  value.
+</p>
+<p>
+  For :rom:cls:`WebRtcEndpoint`, this value should be left as default, as remote
+  WebRTC receivers will already send feedback to inform the media server about
+  what is the optimal bitrate to send.
+</p>
+<p>
+  Setting a value will only work if done before the media starts to flow.
+</p>
+<ul>
+  <li>Unit: bps (bits per second).</li>
+  <li>Default: 300000 (300 kbps).</li>
+</ul>
+          ",
+          "type": "int"
+        },
+        {
           "name": "minOuputBitrate",
-          "doc": "Minimum video bandwidth for transcoding.
-@deprecated Deprecated due to a typo. Use :rom:meth:`minOutputBitrate` instead of this function.",
+          "doc": "Minimum video bitrate for media transcoding.
+@deprecated Use :rom:attr:`minEncoderBitrate` instead of this property.
+          ",
           "type": "int"
         },
         {
           "name": "minOutputBitrate",
-          "doc": "Minimum video bitrate for transcoding.
+          "doc": "Minimum video bitrate for media transcoding.
+@deprecated Use :rom:attr:`minEncoderBitrate` instead of this property.
+          ",
+          "type": "int"
+        },
+        {
+          "name": "minEncoderBitrate",
+          "doc": "Minimum video bitrate for media transcoding.
+<p>
+  This parameter can be used to fine tune the automatic bitrate selection that
+  normally takes place within elements that are able to dynamically change the
+  encoding bitrate according to the conditions of the streaming, such as
+  :rom:cls:`WebRtcEndpoint`.
+</p>
+<p>
+  This should be left as default in most cases, given that remote WebRTC
+  receivers already send feedback to inform the media server about what is the
+  optimal bitrate to send. Otherwise, this parameter could be used for example
+  to force a higher bitrate than what is being requested by receivers.
+</p>
+<p>
+  Setting a value will only work if done before the media starts to flow.
+</p>
 <ul>
   <li>Unit: bps (bits per second).</li>
   <li>Default: 0.</li>
@@ -1337,17 +1392,43 @@ Pipeline, towards the associated producer. Only valid for video consumers.
         },
         {
           "name": "maxOuputBitrate",
-          "doc": "Maximum video bandwidth for transcoding.
-@deprecated Deprecated due to a typo. Use :rom:meth:`maxOutputBitrate` instead of this function.",
+          "doc": "Maximum video bitrate for media transcoding.
+@deprecated Use :rom:attr:`maxEncoderBitrate` instead of this property.
+          ",
           "type": "int"
         },
         {
           "name": "maxOutputBitrate",
-          "doc": "Maximum video bitrate for transcoding.
+          "doc": "Maximum video bitrate for media transcoding.
+@deprecated Use :rom:attr:`maxEncoderBitrate` instead of this property.
+          ",
+          "type": "int"
+        },
+        {
+          "name": "maxEncoderBitrate",
+          "doc": "Maximum video bitrate for media transcoding.
+<p>
+  This parameter can be used to fine tune the automatic bitrate selection that
+  normally takes place within elements that are able to dynamically change the
+  encoding bitrate according to the conditions of the streaming, such as
+  :rom:cls:`WebRtcEndpoint`.
+</p>
+<p>
+  This should be left as default in most cases, given that remote WebRTC
+  receivers already send feedback to inform the media server about what is the
+  optimal bitrate to send. Otherwise, this parameter could be used for example
+  to limit the total bitrate that is handled by the server, by setting a low
+  maximum output for all endpoints.
+</p>
+<p>
+  Setting a value will only work if done before the media starts to flow.
+</p>
 <ul>
   <li>Unit: bps (bits per second).</li>
-  <li>Default: MAXINT.</li>
-  <li>0 = unlimited.</li>
+  <li>Default: 0.</li>
+  <li>
+    0 = unlimited. Encoding performed with bitrate as requested by receivers.
+  </li>
 </ul>
           ",
           "type": "int"

--- a/tests/check/element/passthrough.c
+++ b/tests/check/element/passthrough.c
@@ -272,8 +272,8 @@ GST_START_TEST (check_bitrate)
   g_object_set (capsfilter, "caps", caps, NULL);
   gst_caps_unref (caps);
 
-  g_object_set (passthrough, "min-output-bitrate", BITRATE,
-      "max-output-bitrate", BITRATE, NULL);
+  g_object_set (passthrough, "target-encoder-bitrate", BITRATE,
+      "min-encoder-bitrate", BITRATE, "max-encoder-bitrate", BITRATE, NULL);
 
   g_object_set_qdata (G_OBJECT (passthrough), video_sink_quark (), capsfilter);
   g_signal_connect (passthrough, "pad-added",


### PR DESCRIPTION
The old "OutputBitrate" properties, introduced in

* https://github.com/Kurento/kms-core/commit/f2392542e86d511efc2c0f0bc92aaabcef4ad890
* https://github.com/Kurento/kms-core/commit/8442de9d6a3116a4425bc9bb559e9c4b7fc6a7eb

had several problems:

* They were confusing. The naming of these properties is only vaguely related to their exact behavior, and the "Output" word only added confusion given all the other parameters that exist, such as all the combinations of "(Max|Min)(Audio|Video)(Recv|Send)Bandwidth".

    In reality, the *OutputBitrate* properties had nothing to do with those, as they pertained exclusively to the **output bitrate of the video encoder** when transcoding is activated within the media server.

* They didn't do what they promised. Only *OutputBitrateMin* and *OutputBitrateMax* where exposed, but the actual target bitrate was still **hardcoded at 300 kbps**. This means that with a minimum below 300, or a maximum above 300, the resulting bitrate would still be always 300.

    For example, it was impossible to have a minimum of 100 kbps, an average target of 500 kbps, and a maximum of 1 Mbps. This caused even more confusion, because users didn't understand why their transcoded recordings where getting only 300 kbps even though they allowed for a higher quality output with the "Max" property.

This change makes it very clear to both users and developers what there values are about. Also, the addition of "TargetEncoderBitrate" allows to request an average target that is different from the previously hardcoded 300 kbps, even without touching the Min and Max limits.

Docs have also been extended to explain what these values do.
